### PR TITLE
分离各模块的初始化函数

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ project(D5RC VERSION 0.2)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
+# 设置 OpenCV 的搜索路径
+set(OpenCV_DIR "${CMAKE_CURRENT_SOURCE_DIR}/lib/Galaxy/lib/OpenCV_4_10") # 若使用 Mingw，则需要正确设置 OpenCV_DIR, 并将库地址添加到环境变量中
+
 add_subdirectory(lib/RMD)
 add_subdirectory(lib/Nator)
 add_subdirectory(lib/Galaxy)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 # 设置 OpenCV 的搜索路径
 set(OpenCV_DIR "${CMAKE_CURRENT_SOURCE_DIR}/lib/Galaxy/lib/OpenCV_4_10") # 若使用 Mingw，则需要正确设置 OpenCV_DIR, 并将库地址添加到环境变量中
 
+add_compile_definitions(ROOT_DIR="${CMAKE_CURRENT_SOURCE_DIR}") # 定义项目根目录
+
 add_subdirectory(lib/RMD)
 add_subdirectory(lib/Nator)
 add_subdirectory(lib/Galaxy)

--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@
 
 ### 配置编译器
 
-将 Cmake 的编译器设置留空，或设置为 MSVC（OpenCV PreBuilt 包不支持 Mingw，若要使用请自行解决）
+基于上面配置 OpenCV 选择的方法，对应地配置 Cmake 的编译器

--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@
 
 ### 配置 OpenCV
 
+#### 使用 MinGW
+
+本仓库内部已包含 OpenCV 的 MinGW 预编译版本
+
+1. 确保 `CMakeLists.txt` 中正确设置了 `OpenCV_DIR` 
+2. 将 `lib/Galaxy/OpenCV_4_10/x64/bin` 添加到环境变量的 `Path` 中
+
+#### 使用 MSbuild
+
+> [!CAUTION]  
+> 此方法未充分测试，在部分电脑上会无法正常运行
+
 1. 去 OpenCV 官网下载 PreBuilt 包并安装 [[链接在此](https://github.com/opencv/opencv/releases/latest)]
 2. 将如下路径添加进环境变量的 Path 中  
     `path\to\opencv\build\x64\vc16\bin`  

--- a/include/D5Robot.h
+++ b/include/D5Robot.h
@@ -20,18 +20,21 @@ struct Points {
 
 class D5Robot {
   private:
-    SerialPort _port; // 该声明必须在 RMDMotor 声明之前
+    SerialPort *_port; // 该声明必须在 RMDMotor 声明之前
 
   public:
-    NatorMotor natorMotor;
-    RMDMotor topRMDMotor;
-    RMDMotor botRMDMotor;
+    NatorMotor *natorMotor;
+    RMDMotor *topRMDMotor;
+    RMDMotor *botRMDMotor;
     CameraUP *upCamera = nullptr;
 
+    D5Robot();
     D5Robot(const char *serialPort, std::string natorID = NatorId,
             uint8_t topRMDID = 1, uint8_t botRMDID = 2,
             std::string upCameraID = UpCameraId);
     ~D5Robot();
+    void InitNator(std::string natorID = NatorId);
+    void InitRMD(const char *portName, uint8_t topRMDID = 1, uint8_t botRMDID = 2);
     void InitCamera(std::string upCameraId = UpCameraId);
     bool IsInit();
     bool SetZero();

--- a/include/ErrorCode.h
+++ b/include/ErrorCode.h
@@ -25,6 +25,8 @@ enum ErrorCode {
     RMDMoveError,
     D5RError = 500,
     D5RMoveError,
+    D5RNatorNotInitialized,
+    D5RRMDMotorNotInitialized,
     D5RCameraNotInitialized,
     CameraError = 600,
     CameraInitError,

--- a/include/RobotException.hpp
+++ b/include/RobotException.hpp
@@ -7,15 +7,15 @@
 namespace D5R {
 
 class RobotException : public std::exception {
-public:
-  ErrorCode code;
-  std::string msg;
-  RobotException() noexcept {};
-  RobotException(ErrorCode code) noexcept { this->code = code; }
-  RobotException(ErrorCode code, std::string msg) noexcept {
-      this->code = code;
-      this->msg = msg;
-  }
+  public:
+    ErrorCode code;
+    std::string msg;
+    RobotException() noexcept {};
+    RobotException(ErrorCode code) noexcept { this->code = code; }
+    RobotException(ErrorCode code, std::string msg) noexcept {
+        this->code = code;
+        this->msg = msg;
+    }
   RobotException(const RobotException &other) noexcept : code(other.code) {}
   RobotException &operator=(const RobotException &other) noexcept {
     this->code = other.code;
@@ -23,29 +23,40 @@ public:
   }
 
   const char *what() const noexcept {
-      std::string str;
-      switch (code) {
-      case ErrorCode::OK:
-          return "OK";
-      case ErrorCode::SystemError:
-          return "System Error";
-      case ErrorCode::CreateInstanceError:
-          return "Create Instance Error";
-      case ErrorCode::SerialError:
-          return "Serial Error";
-      case ErrorCode::SerialInitError:
-          return "Serial Init Error";
-      case ErrorCode::NatorError:
-          return "Nator Error";
-      case ErrorCode::RMDError:
-          return "RMD Error";
-      case ErrorCode::CameraError:
-          return "Camera Error";
-      default:
-          std::string s = "Other Error: " + std::to_string(code);
-          return s.c_str();
-    }
-    return str.c_str();
+      std::string whatInfo; // 注意这里的字符串不能以 e/E 开头，否则会乱码，原因不明
+      if (!this->msg.empty()) {
+          whatInfo = (this->msg + " Errorcode: " + std::to_string(this->code));
+      } else {
+          whatInfo = ("The Error code: " + std::to_string(this->code)); // 注意这里的字符串不能以 e/E 开头，否则会乱码，原因不明
+      }
+
+      // *_whatInfo = whatInfo.c_str();
+
+      return whatInfo.c_str();
+
+      // std::string str;
+      // switch (code) {
+      // case ErrorCode::OK:
+      //     return "OK";
+      // case ErrorCode::SystemError:
+      //     return "System Error";
+      // case ErrorCode::CreateInstanceError:
+      //     return "Create Instance Error";
+      // case ErrorCode::SerialError:
+      //     return "Serial Error";
+      // case ErrorCode::SerialInitError:
+      //     return "Serial Init Error";
+      // case ErrorCode::NatorError:
+      //     return "Nator Error";
+      // case ErrorCode::RMDError:
+      //     return "RMD Error";
+      // case ErrorCode::CameraError:
+      //     return "Camera Error";
+      // default:
+      //     std::string s = "Other Error: " + std::to_string(code);
+      //     return s.c_str();
+      // }
+      // return str.c_str();
   }
 };
 

--- a/include/RobotException.hpp
+++ b/include/RobotException.hpp
@@ -27,7 +27,7 @@ class RobotException : public std::exception {
       if (!this->msg.empty()) {
           whatInfo = (this->msg + " Errorcode: " + std::to_string(this->code));
       } else {
-          whatInfo = ("The Error code: " + std::to_string(this->code)); // 注意这里的字符串不能以 e/E 开头，否则会乱码，原因不明
+          whatInfo = ("The Error code: " + std::to_string(this->code)); // 注意这里的字符串不能以 e/E 开头，否则可能会乱码，原因不明
       }
 
       // *_whatInfo = whatInfo.c_str();

--- a/include/RobotException.hpp
+++ b/include/RobotException.hpp
@@ -23,17 +23,16 @@ class RobotException : public std::exception {
   }
 
   const char *what() const noexcept {
-      std::string whatInfo; // 注意这里的字符串不能以 e/E 开头，否则会乱码，原因不明
+      std::string whatInfo;
       if (!this->msg.empty()) {
           whatInfo = (this->msg + " Errorcode: " + std::to_string(this->code));
       } else {
-          whatInfo = ("The Error code: " + std::to_string(this->code)); // 注意这里的字符串不能以 e/E 开头，否则会乱码，原因不明
+          whatInfo = ("The Error code: " + std::to_string(this->code)); // 注意这里的字符串不能以 e/E 开头，否则可能会乱码，原因不明
       }
-
-      // *_whatInfo = whatInfo.c_str();
 
       return whatInfo.c_str();
 
+      // TODO: 测试后删除以下注释
       // std::string str;
       // switch (code) {
       // case ErrorCode::OK:

--- a/lib/Galaxy/CameraUP.cpp
+++ b/lib/Galaxy/CameraUP.cpp
@@ -8,24 +8,24 @@ namespace D5R {
  */
 CameraUP::CameraUP(std::string id) : GxCamera(id) {
     // 夹钳模板
-
-    _clamp.img = cv::imread("E:/WYL_workspace/D5RC/lib/Galaxy/image/model/clamp.png", 0);
+    std::string root(ROOT_DIR);
+    _clamp.img = cv::imread(root + "/lib/Galaxy/image/model/clamp.png", 0);
     _clamp.center = cv::Point2f(448, 63);
     _clamp.point = cv::Point2f(445.8, 101);
-    cv::FileStorage fs1("E:/WYL_workspace/D5RC/lib/Galaxy/image/yml/KeyPoints_Clamp.yml", cv::FileStorage::READ);
+    cv::FileStorage fs1(root + "/lib/Galaxy/image/yml/KeyPoints_Clamp.yml", cv::FileStorage::READ);
     fs1["keypoints"] >> _clamp.keypoints;
     fs1.release();
-    cv::FileStorage fs2("E:/WYL_workspace/D5RC/lib/Galaxy/image/yml/Descriptors_Clamp.yml", cv::FileStorage::READ);
+    cv::FileStorage fs2(root + "/lib/Galaxy/image/yml/Descriptors_Clamp.yml", cv::FileStorage::READ);
     fs2["descriptors"] >> _clamp.descriptors;
     fs2.release();
     // 钳口模板
-    _jaw.img = cv::imread("E:/WYL_workspace/D5RC/lib/Galaxy/image/model/jaw_model.png", 0);
+    _jaw.img = cv::imread(root + "/lib/Galaxy/image/model/jaw_model.png", 0);
     _jaw.center = cv::Point2f(318, 408.5);
     _jaw.point = cv::Point2f(318, 44);
-    cv::FileStorage fs3("E:/WYL_workspace/D5RC/lib/Galaxy/image/yml/KeyPoints_Jaw.yml", cv::FileStorage::READ);
+    cv::FileStorage fs3(root + "/lib/Galaxy/image/yml/KeyPoints_Jaw.yml", cv::FileStorage::READ);
     fs3["keypoints"] >> _jaw.keypoints;
     fs3.release();
-    cv::FileStorage fs4("E:/WYL_workspace/D5RC/lib/Galaxy/image/yml/Descriptors_Jaw.yml", cv::FileStorage::READ);
+    cv::FileStorage fs4(root + "/lib/Galaxy/image/yml/Descriptors_Jaw.yml", cv::FileStorage::READ);
     fs4["descriptors"] >> _jaw.descriptors;
     fs4.release();
 

--- a/lib/Nator/NatorMotor.cpp
+++ b/lib/Nator/NatorMotor.cpp
@@ -17,7 +17,7 @@ NatorMotor::NatorMotor(std::string id) : _id(id) {
   if(!_isInit)
   {
     std::cerr << "Failed to init NatorMotor" << std::endl;
-    throw RobotException(ErrorCode::NatorInitError);
+    throw RobotException(ErrorCode::NatorInitError, "In NatorMotor constructor: Failed to init NatorMotor");
   }
 }
 NatorMotor::~NatorMotor() { NT_CloseSystem(_handle); }

--- a/lib/RMD/SerialPort.cpp
+++ b/lib/RMD/SerialPort.cpp
@@ -9,14 +9,14 @@ SerialPort::SerialPort(const char *serialPort) {
   _handle = CreateFile(serialPort, GENERIC_READ | GENERIC_WRITE, 0, 0,
                        OPEN_EXISTING, 0, 0);
   if (_handle == INVALID_HANDLE_VALUE) {
-    throw RobotException(ErrorCode::SerialInitError);
-    return;
+      throw RobotException(ErrorCode::SerialInitError, "In SerialPort constructor: Failed to open serial port");
+      return;
   }
 
   BOOL bSuccess = SetupComm(_handle, 100, 100);
   if (!bSuccess) {
-    throw RobotException(ErrorCode::SerialInitError);
-    return;
+      throw RobotException(ErrorCode::SerialInitError, "In SerialPort constructor: Failed to Setup Comm");
+      return;
   }
 
   COMMTIMEOUTS commTimeouts = {0};
@@ -28,23 +28,23 @@ SerialPort::SerialPort(const char *serialPort) {
 
   bSuccess = SetCommTimeouts(_handle, &commTimeouts);
   if (!bSuccess) {
-    throw RobotException(ErrorCode::SerialInitError);
-    return;
+      throw RobotException(ErrorCode::SerialInitError, "In SerialPort constructor: Failed to Set Comm Timeouts");
+      return;
   }
 
   DCB dcbSerialParams = {0};
   dcbSerialParams.DCBlength = sizeof(dcbSerialParams);
   if (!GetCommState(_handle, &dcbSerialParams)) {
-    throw RobotException(ErrorCode::SerialInitError);
-    return;
+      throw RobotException(ErrorCode::SerialInitError, "In SerialPort constructor: Failed to Get Comm State");
+      return;
   }
   dcbSerialParams.BaudRate = CBR_115200;
   dcbSerialParams.ByteSize = 8;
   dcbSerialParams.StopBits = ONESTOPBIT;
   dcbSerialParams.Parity = NOPARITY;
   if (!SetCommState(_handle, &dcbSerialParams)) {
-    throw RobotException(ErrorCode::SerialInitError);
-    return;
+      throw RobotException(ErrorCode::SerialInitError, "In SerialPort constructor: Failed to Set Comm State");
+      return;
   }
 }
 

--- a/src/D5Robot.cpp
+++ b/src/D5Robot.cpp
@@ -4,29 +4,46 @@ namespace D5R {
 
 Joints JAWPOINT{}; // 钳口位置，需要实验确定
 
+D5Robot::D5Robot() {
+}
+
 D5Robot::D5Robot(
     const char *serialPort,
     std::string natorID,
     uint8_t topRMDID,
     uint8_t botRMDID,
-    std::string upCameraID)
-    : _port(serialPort),
-      topRMDMotor(_port.GetHandle(), topRMDID),
-      botRMDMotor(_port.GetHandle(), botRMDID),
-      natorMotor(natorID) {
-    // topRMDMotor._id = topRMDID;
-    // topRMDMotor._handle = _port.GetHandle();
-    // botRMDMotor._id = botRMDID;
-    // botRMDMotor._handle = _port.GetHandle();
-    // upCamera = new CameraUP(upCameraID);
-    _isInit = natorMotor.IsInit();
-    if (!_isInit) {
-        throw RobotException(ErrorCode::CreateInstanceError);
-    }
+    std::string upCameraID) {
+    InitNator(natorID);
+    InitRMD(serialPort, topRMDID, botRMDID);
+    InitCamera(upCameraID);
+    // _isInit = natorMotor.IsInit();
+    // if (!_isInit) {
+    //     throw RobotException(ErrorCode::CreateInstanceError);
+    // }
 }
 D5Robot::~D5Robot() {
     delete upCamera;
     upCamera = nullptr;
+}
+
+void D5Robot::InitNator(std::string natorID) {
+    natorMotor = new NatorMotor(natorID);
+}
+
+/**
+ * @brief Initializes the RMD motor with the given port name and IDs.
+ *
+ * This function sets up the RMD motor with the given port name and IDs.
+ * The IDs are used to identify the motor when sending commands.
+ *
+ * @param portName The serial port name to use for the motor.
+ * @param topRMDID The ID of the top RMD motor.
+ * @param botRMDID The ID of the bottom RMD motor.
+ */
+void D5Robot::InitRMD(const char *portName, uint8_t topRMDID, uint8_t botRMDID) {
+    _port = new SerialPort(portName);
+    topRMDMotor = new RMDMotor(portName, topRMDID);
+    botRMDMotor = new RMDMotor(portName, botRMDID);
 }
 
 void D5Robot::InitCamera(std::string upCameraId) {
@@ -36,30 +53,44 @@ void D5Robot::InitCamera(std::string upCameraId) {
 bool D5Robot::IsInit() { return _isInit; }
 
 bool D5Robot::SetZero() {
-    if (!natorMotor.SetZero()) {
-        ERROR_("Failed to set nator motor zero");
+    if (!natorMotor) {
+        throw RobotException(ErrorCode::D5RNatorNotInitialized, "In D5Robot::SetZero: natorMotor is not initialized. Call InitNator first.");
+    }
+    if (!topRMDMotor || !botRMDMotor) {
+        throw RobotException(ErrorCode::D5RRMDMotorNotInitialized, "In D5Robot::SetZero: RMDMotor is not initialized. Call InitRMD first.");
+    }
+
+    if (!natorMotor->SetZero()) {
+        ERROR_("In D5Robot::SetZero: Failed to set nator motor zero");
         return false;
     }
-    if (!topRMDMotor.SetZero()) {
-        ERROR_("Failed to set TOP RMD motor zero");
+    if (!topRMDMotor->SetZero()) {
+        ERROR_("In D5Robot::SetZero: Failed to set TOP RMD motor zero");
         return false;
     }
-    if (!botRMDMotor.SetZero()) {
-        ERROR_("Failed to set BOT RMD motor zero");
+    if (!botRMDMotor->SetZero()) {
+        ERROR_("In D5Robot::SetZero: Failed to set BOT RMD motor zero");
         return false;
     }
     return true;
 }
 bool D5Robot::Stop() {
-    if (!natorMotor.Stop()) {
+    if (!natorMotor) {
+        throw RobotException(ErrorCode::D5RNatorNotInitialized, "In D5Robot::Stop: natorMotor is not initialized. Call `InitNator` first.");
+    }
+    if (!topRMDMotor || !botRMDMotor) {
+        throw RobotException(ErrorCode::D5RRMDMotorNotInitialized, "In D5Robot::Stop: RMDMotor is not initialized. Call `InitRMD` first.");
+    }
+
+    if (!natorMotor->Stop()) {
         ERROR_("Failed to stop nator motor");
         return false;
     }
-    if (!topRMDMotor.Stop()) {
+    if (!topRMDMotor->Stop()) {
         ERROR_("Failed to stop TOP RMD motor");
         return false;
     }
-    if (!botRMDMotor.Stop()) {
+    if (!botRMDMotor->Stop()) {
         ERROR_("Failed to stop BOT RMD motor");
         return false;
     }
@@ -67,34 +98,48 @@ bool D5Robot::Stop() {
 }
 
 bool D5Robot::JointsMoveAbsolute(const Joints j) {
+    if (!natorMotor) {
+        throw RobotException(ErrorCode::D5RNatorNotInitialized, "In D5Robot::JointsMoveAbsolute: natorMotor is not initialized. Call `InitNator` first.");
+    }
+    if (!topRMDMotor || !botRMDMotor) {
+        throw RobotException(ErrorCode::D5RRMDMotorNotInitialized, "In D5Robot::JointsMoveAbsolute: RMDMotor is not initialized. Call `InitRMD` first.");
+    }
+
     NTU_Point p{j.p2, j.p3, j.p4};
-    if (!natorMotor.GoToPoint_A(p)) {
+    if (!natorMotor->GoToPoint_A(p)) {
         ERROR_("Failed to move nator motor");
         return false;
     }
-    if (!topRMDMotor.GoAngleAbsolute(j.r1)) {
+    if (!topRMDMotor->GoAngleAbsolute(j.r1)) {
         ERROR_("Failed to move top RMD motor");
         return false;
     }
-    if (!botRMDMotor.GoAngleAbsolute(j.r5)) {
+    if (!botRMDMotor->GoAngleAbsolute(j.r5)) {
         ERROR_("Failed to move bot RMD motor");
         return false;
     }
     return true;
 }
 bool D5Robot::JointsMoveRelative(const Joints j) {
+    if (!natorMotor) {
+        throw RobotException(ErrorCode::D5RNatorNotInitialized, "In D5Robot::JointsMoveRelative: natorMotor is not initialized. Call `InitNator` first.");
+    }
+    if (!topRMDMotor || !botRMDMotor) {
+        throw RobotException(ErrorCode::D5RRMDMotorNotInitialized, "In D5Robot::JointsMoveRelative: RMDMotor is not initialized. Call `InitRMD` first.");
+    }
+
     NTU_Point p{j.p2, j.p3, j.p4};
-    if (!natorMotor.GoToPoint_R(p)) {
+    if (!natorMotor->GoToPoint_R(p)) {
         ERROR_("Failed to move nator motor");
         throw RobotException(ErrorCode::NatorMoveError);
         return false;
     }
-    if (!topRMDMotor.GoAngleRelative(j.r1)) {
+    if (!topRMDMotor->GoAngleRelative(j.r1)) {
         ERROR_("Failed to move top RMD motor");
         throw RobotException(ErrorCode::RMDMoveError);
         return false;
     }
-    if (!botRMDMotor.GoAngleRelative(j.r5)) {
+    if (!botRMDMotor->GoAngleRelative(j.r5)) {
         ERROR_("Failed to move bot RMD motor");
         throw RobotException(ErrorCode::RMDMoveError);
         return false;
@@ -114,13 +159,20 @@ bool D5Robot::TaskMoveRelative(const TaskSpace ts) {
 }
 
 Joints D5Robot::GetCurrentJoint() {
+    if (!natorMotor) {
+        throw RobotException(ErrorCode::D5RNatorNotInitialized, "In D5Robot::GetCurrentJoint: natorMotor is not initialized. Call `InitNator` first.");
+    }
+    if (!topRMDMotor || !botRMDMotor) {
+        throw RobotException(ErrorCode::D5RRMDMotorNotInitialized, "In D5Robot::GetCurrentJoint: RMDMotor is not initialized. Call `InitRMD` first.");
+    }
+
     Joints j;
 
-    j.r1 = topRMDMotor.GetSingleAngle_s();
-    j.r5 = botRMDMotor.GetSingleAngle_s();
+    j.r1 = topRMDMotor->GetSingleAngle_s();
+    j.r5 = botRMDMotor->GetSingleAngle_s();
 
     NTU_Point np;
-    this->natorMotor.GetPosition(&np);
+    this->natorMotor->GetPosition(&np);
     j.p2 = np.x;
     j.p3 = np.y;
     j.p4 = np.z;

--- a/test.cpp
+++ b/test.cpp
@@ -15,29 +15,42 @@ int main() {
     // TestMoving();
     // TestApi();
     // TestKineHelper();
+    // D5R::D5Robot robot(port.c_str());
+    D5R::D5Robot robot;
+
     try {
-        D5R::D5Robot robot(port.c_str());
-        robot.JointsMoveAbsolute({300, -4000000, 1800000, -7000000, 0}); // 别动
-
-        // robot.Stop();
-        // robot.JointsMoveAbsolute({300, 0, 0, -10000000, 0});
-        // robot.JointsMoveAbsolute({0, 500000, 6000000, -7000000, 0});
-        // Sleep(5000);
-        // int64 start = cv::getTickCount();
-        // robot.upCamera.GetPixelPos();
-        // int64 end = cv::getTickCount();
-        // int64 t = 1000.0 * (end - start) / cv::getTickFrequency();
-        // std::cout << t << std::endl;
-        // cv::waitKey(0);
-
-        robot.VCJawChange();
-        cv::waitKey(0);
-
+        robot.InitNator(natorID);
     } catch (D5R::RobotException &e) {
         std::cout << e.what() << std::endl;
-
-        throw;
     }
+
+    try {
+        robot.InitRMD(port.c_str());
+    } catch (D5R::RobotException &e) {
+        std::cout << e.what() << std::endl;
+    }
+
+    try {
+        robot.InitCamera();
+    } catch (D5R::RobotException &e) {
+        std::cout << e.what() << std::endl;
+    }
+
+    // robot.JointsMoveAbsolute({300, -4000000, 1800000, -7000000, 0}); // 别动
+
+    // robot.Stop();
+    // robot.JointsMoveAbsolute({300, 0, 0, -10000000, 0});
+    // robot.JointsMoveAbsolute({0, 500000, 6000000, -7000000, 0});
+    // Sleep(5000);
+    // int64 start = cv::getTickCount();
+    // robot.upCamera.GetPixelPos();
+    // int64 end = cv::getTickCount();
+    // int64 t = 1000.0 * (end - start) / cv::getTickFrequency();
+    // std::cout << t << std::endl;
+    // cv::waitKey(0);
+
+    robot.VCJawChange();
+    cv::waitKey(0);
 
     // cv::Mat img;
     // cv::Point2f roiP(800, 648);

--- a/test.cpp
+++ b/test.cpp
@@ -15,21 +15,29 @@ int main() {
     // TestMoving();
     // TestApi();
     // TestKineHelper();
-    D5R::D5Robot robot(port.c_str());
-    // robot.Stop();
-    // robot.JointsMoveAbsolute({300, 0, 0, -10000000, 0});
-    // robot.JointsMoveAbsolute({0, 500000, 6000000, -7000000, 0});
-    robot.JointsMoveAbsolute({300, -4000000, 1800000, -7000000, 0}); // 别动
-    // Sleep(5000);
-    // int64 start = cv::getTickCount();
-    // robot.upCamera.GetPixelPos();
-    // int64 end = cv::getTickCount();
-    // int64 t = 1000.0 * (end - start) / cv::getTickFrequency();
-    // std::cout << t << std::endl;
-    // cv::waitKey(0);
+    try {
+        D5R::D5Robot robot(port.c_str());
+        robot.JointsMoveAbsolute({300, -4000000, 1800000, -7000000, 0}); // 别动
 
-    robot.VCJawChange();
-    cv::waitKey(0);
+        // robot.Stop();
+        // robot.JointsMoveAbsolute({300, 0, 0, -10000000, 0});
+        // robot.JointsMoveAbsolute({0, 500000, 6000000, -7000000, 0});
+        // Sleep(5000);
+        // int64 start = cv::getTickCount();
+        // robot.upCamera.GetPixelPos();
+        // int64 end = cv::getTickCount();
+        // int64 t = 1000.0 * (end - start) / cv::getTickFrequency();
+        // std::cout << t << std::endl;
+        // cv::waitKey(0);
+
+        robot.VCJawChange();
+        cv::waitKey(0);
+
+    } catch (D5R::RobotException &e) {
+        std::cout << e.what() << std::endl;
+
+        throw;
+    }
 
     // cv::Mat img;
     // cv::Point2f roiP(800, 648);


### PR DESCRIPTION
## Change

- 分离了Nator, RMD Carema 模块的初始化函数，使得可以按需启用
- 新增一个默认不进行初始化的 D5Robot 构造函数
- 更新了使用指南
- 重写了 RobotException 的 what() 函数，补充了部分函数抛出的异常信息
- 添加一个根目录的宏定义，优化项目对绝对路径的依赖